### PR TITLE
Change to read onboard thermo sensor if available

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,11 +5,13 @@ import time
 
 
 def get_temp():
-    return random.randint(0, 50)
-
+    try:
+        return int(open('/sys/class/thermal/thermal_zone0/temp').read())/1000.0
+    except:
+        return random.randint(0, 50)
 
 if __name__ == '__main__':
     while True:
-        data = { 'temperature': get_temp() } 
+        data = { 'temperature': get_temp() }
         print(json.dumps(data))
         time.sleep(60)


### PR DESCRIPTION
If the device has onboard thermo-sensor in the path `/sys/class/thermal/thermal_zone0/temp` , it reports the temperature instead of random value.

It works on Raspberry Pis and maybe on other SBCs, too.